### PR TITLE
feat: consider cursor column in context fetch

### DIFF
--- a/lua/anyline/animate.lua
+++ b/lua/anyline/animate.lua
@@ -21,19 +21,19 @@ local markager = require('anyline.markager')
 local function delay_marks(bufnr, marks, hls, move_delay, color_delay, char)
 	local timers = {}
 	local move_timers = utils.delay_map(marks, move_delay, function(mark)
-		if not mark.opts then goto continue end
-		local color_timers = utils.delay_map(hls, color_delay, function(hl) --
-			markager.set_extmark(
-				bufnr,
-				mark.row,
-				mark.column,
-				hl,
-				char,
-				{ priority = mark.opts.priority + 1, id = mark.id }
-			)
-		end)
-		timers = table.add(timers, color_timers)
-		::continue::
+		if mark.opts then
+			local color_timers = utils.delay_map(hls, color_delay, function(hl) --
+				markager.set_extmark(
+					bufnr,
+					mark.row,
+					mark.column,
+					hl,
+					char,
+					{ priority = mark.opts.priority + 1, id = mark.id }
+				)
+			end)
+			timers = table.add(timers, color_timers)
+		end
 	end)
 	timers = table.add(timers, move_timers)
 	return timers
@@ -183,9 +183,7 @@ local function cursor_test(direction, color, type)
 	---@param ctx context
 	return function(bufnr, ctx)
 		local cursor = vim.api.nvim_win_get_cursor(0)[1] - 1
-		if type == 'hide' then
-			cursor = M.last_cursor_pos or cursor
-		end
+		if type == 'hide' then cursor = M.last_cursor_pos or cursor end
 
 		local above_start, above_end, below_start, below_end =
 			get_direction_marks(ctx, cursor, direction)
@@ -218,11 +216,6 @@ function M.no_animation(color)
 		local marks = markager.context_range(bufnr, ctx.startln, ctx.endln, ctx.column)
 		delay_marks(ctx.bufnr, marks, { color }, 0, 0)
 	end
-
-
-
-
-
 end
 
 function M.top_down(color) return directional('top_down', color) end
@@ -244,10 +237,6 @@ local animations = {
 
 function M.create_animations(animation)
 	local ani = animations[animation]
-
-
-
-
 
 	if not ani then
 		vim.notify('No such animation "' .. opts.animation .. '"', vim.log.levels.ERROR)

--- a/lua/anyline/autocmds.lua
+++ b/lua/anyline/autocmds.lua
@@ -106,7 +106,4 @@ function M.create()
 	})
 end
 
--- M.delete()
--- M.create()
-
 return M

--- a/lua/anyline/autocmds.lua
+++ b/lua/anyline/autocmds.lua
@@ -97,8 +97,7 @@ function M.create()
 		'TextChanged',
 		'TextChangedI',
 		'CompleteChanged',
-		'BufWinEnter',
-		'BufWritePost',
+		'BufReadPost',
 		'SessionLoadPost',
 	}, {
 		group = group,

--- a/lua/anyline/autocmds.lua
+++ b/lua/anyline/autocmds.lua
@@ -104,6 +104,15 @@ function M.create()
 		group = group,
 		callback = hard_refresh,
 	})
+
+	autocmd('OptionSet', {
+		pattern = { 'tabstop', 'shiftwidth', 'expandtab' },
+		group = group,
+		callback = function()
+			local bufnr = vim.api.nvim_get_current_buf()
+			hard_refresh { buf = bufnr }
+		end,
+	})
 end
 
 return M

--- a/lua/anyline/cache.lua
+++ b/lua/anyline/cache.lua
@@ -74,6 +74,8 @@ local function convert_cache_format(cached_lines)
 	return ranges
 end
 
+M.get_indent_width = get_indent_width
+
 function M.get_cache(bufnr)
 	bufnr = bufnr or vim.api.nvim_get_current_buf()
 	if not M.buffer_caches[bufnr] then M.update_cache(bufnr) end

--- a/lua/anyline/context.lua
+++ b/lua/anyline/context.lua
@@ -46,7 +46,7 @@ function M.get_context_info(bufnr)
 	if vim.api.nvim_buf_is_valid(bufnr) then
 		line_len = #vim.api.nvim_buf_get_lines(bufnr, cursor, cursor + 1, true)[1]
 	end
-	local next = current_indentation(bufnr, cursor + 1, math.min(col, math.max(line_len, 1)))
+	local next = current_indentation(bufnr, cursor + 1, math.min(col, line_len))
 
 	if not column and not next then return end
 

--- a/lua/anyline/debounce.lua
+++ b/lua/anyline/debounce.lua
@@ -1,6 +1,5 @@
 local uv = vim.loop
 
-
 ---@class Debounce
 ---@field timer uv.uv_timer_t | nil
 ---@field fn function

--- a/lua/anyline/init.lua
+++ b/lua/anyline/init.lua
@@ -1,20 +1,49 @@
 local M = {}
 
-local setup = vim.schedule_wrap(function(user_opts)
-	require('anyline.opts').parse_opts(user_opts or {})
+function M.setup(user_opts)
+	vim.schedule(function()
+		require('anyline.opts').parse_opts(user_opts or {})
 
-	local opts = require('anyline.opts').opts
-	vim.api.nvim_set_hl(0, 'AnyLine', { link = opts.highlight })
-	vim.api.nvim_set_hl(0, 'AnyLineContext', { link = opts.context_highlight })
-	vim.api.nvim_create_namespace('AnyLine')
+		local opts = require('anyline.opts').opts
+		vim.api.nvim_set_hl(0, 'AnyLine', { link = opts.highlight })
+		vim.api.nvim_set_hl(0, 'AnyLineContext', { link = opts.context_highlight })
+		vim.api.nvim_create_namespace('AnyLine')
 
-	require('anyline.animate').create_animations(opts.animation)
+		require('anyline.animate').create_animations(opts.animation)
+		require('anyline.autocmds').delete()
+		require('anyline.autocmds').create()
+		M.refresh()
+	end)
+end
+
+function M.refresh(bufnr)
+	bufnr = bufnr or vim.api.nvim_get_current_buf()
+
+	require('anyline.cache').update_cache(bufnr)
+	require('anyline.markager').remove_all_marks(bufnr)
+	require('anyline.setter').set_marks(bufnr)
+	require('anyline.context').show_context(bufnr)
+end
+
+function M.disable()
+	require('anyline.cache').clear_cache()
 	require('anyline.autocmds').delete()
-	require('anyline.autocmds').create()
-end)
+	require('anyline.markager').remove_all_marks()
+	require('anyline.opts').opts.enabled = false
+end
 
-function M.setup(user_opts) --
-	setup(user_opts)
+function M.enable()
+	require('anyline.autocmds').create()
+	M.refresh()
+	require('anyline.opts').opts.enabled = true
+end
+
+function M.toggle()
+	if require('anyline.opts').opts.enabled then
+		M.disable()
+	else
+		M.enable()
+	end
 end
 
 return M

--- a/lua/anyline/opts.lua
+++ b/lua/anyline/opts.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 M.opts = {
+	enabled = true,
 	-- visual stuff
 	indent_char = '▏', -- character to use for the line
 	highlight = 'Comment', -- color of non active indentatino lines


### PR DESCRIPTION
Needs some testing, things break if the file's indentation characters and `expandtab` don't match.

Also adds methods for toggling anyline, and force refreshing marks.

TODO: Alternate method of determining indent characters